### PR TITLE
remove the leading / in tar file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
                   tag=release:$$
                   docker build --tag $tag --build-arg UBUNTU_RELEASE=${{ matrix.RELEASE }} .
                   container=$(docker create $tag)
-                  docker  cp $container:/ - > $tar
+                  docker  cp $container:. - > $tar
                   docker rm $container
                   docker rmi $tag
                   xz $tar


### PR DESCRIPTION
Remove the leading / in tar file it gets removed anyway during the extraction. 
```
gtar: Removing leading `/' from member names
gtar: Removing leading `/' from hard link targets
```
