### PR TITLE
Add jq to the required void packages

### DIFF
--- a/void/helpers/build.sh
+++ b/void/helpers/build.sh
@@ -28,7 +28,8 @@ xbps-install -ySu \
 	iproute2 iputils net-tools \
 	vpm vsv \
 	ncurses-base \
-	openssh joe vim
+	openssh joe vim \
+	jq
 
 xbps-alternatives -g vi -s vim-common
 


### PR DESCRIPTION
Hey everyone this adds jq to the installed packages for void.

Motivation:
I am attempting to share a common image base between this repo and what smartos lx images are built off of. That effort can be seen here https://github.com/joyent/smartos-lx-img-builder

That repo is just a work in progress, I may drastically change it. 
It's currently  just a proof of concept that seems to be working. Either way the outcome will be the same, I want to take userland tar files and generate zfs datasets and manifests for smartos.