### PR TITLE
Fix Service Enable

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -3,4 +3,4 @@ FROM debian:${DEBIAN_RELEASE}
 ARG DEBIAN_RELEASE
 ENV DEBIAN_RELEASE ${DEBIAN_RELEASE}
 COPY helpers /helpers
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN chmod 0 /bin/systemctl;cd /helpers; sh build.sh; cd /; rm -rf helpers;chmod 755 /bin/systemctl

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,4 +2,4 @@ ARG UBUNTU_RELEASE
 FROM ubuntu:${UBUNTU_RELEASE}
 COPY helpers /helpers
 ARG UBUNTU_RELEASE=${UBUNTU_RELEASE}
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN chmod 0 /bin/systemctl;cd /helpers; sh build.sh; cd /; rm -rf helpers;chmod 755 /bin/systemctl


### PR DESCRIPTION
The debian install system checks if /bin/systemctl is executable to figure out
if systemd is running (how stupid is that?). During docker build it is NOT runnig
so we let debian know by removing setting /bin/systemctl to mode 0.