### PR TITLE
ubuntu22: added tzdata package

### DIFF
--- a/ubuntu/helpers/build.sh
+++ b/ubuntu/helpers/build.sh
@@ -23,7 +23,8 @@ apt-get install -yq \
     net-tools \
     iputils-ping \
     locales \
-    rsync
+    rsync \
+    tzdata
 apt-get -qq clean
 apt-get -qq autoremove
 


### PR DESCRIPTION
Currently, only the `UTC` timezone is know to `timedatectl`. By adding this package things like `timedatectl set-timezone Europe/Zurich` are possible again