### PR TITLE
Add some missing packages across all images

### DIFF
--- a/centos-stream/helpers/build.sh
+++ b/centos-stream/helpers/build.sh
@@ -8,8 +8,11 @@ dnf install -y --allowerasing \
     vim \
     binutils \
     dialog \
+    diffutils \
     openssh-server \
     openssh-clients \
+    procps-ng \
+    rsyslog \
     sudo \
     curl \
     less \

--- a/debian/helpers/build.sh
+++ b/debian/helpers/build.sh
@@ -20,6 +20,7 @@ apt-get install -yq \
     joe \
     man-db \
     net-tools \
+    rsyslog \
     iputils-ping
 apt-get -qq clean
 rm -rf /var/lib/apt/lists/*

--- a/devuan/helpers/build.sh
+++ b/devuan/helpers/build.sh
@@ -9,6 +9,7 @@ apt-get install -yq \
     vim \
     binutils \
     cron \
+    dialog \
     openssh-server \
     sudo \
     iproute2 \
@@ -18,6 +19,7 @@ apt-get install -yq \
     joe \
     man-db \
     net-tools \
+    rsyslog \
     iputils-ping
 # Remove the elogind session manager - this will cause the alternative
 # consolekit to be installed automatically

--- a/fedora/helpers/build.sh
+++ b/fedora/helpers/build.sh
@@ -8,8 +8,11 @@ dnf install -y --allowerasing \
     vim \
     binutils \
     dialog \
+    diffutils \
     openssh-server \
     openssh-clients \
+    procps-ng \
+    rsyslog \
     sudo \
     curl \
     less \

--- a/ubuntu/helpers/build.sh
+++ b/ubuntu/helpers/build.sh
@@ -24,6 +24,7 @@ apt-get install -yq \
     iputils-ping \
     locales \
     rsync \
+    rsyslog \
     tzdata
 apt-get -qq clean
 rm -rf /var/lib/apt/lists/*

--- a/void/helpers/build.sh
+++ b/void/helpers/build.sh
@@ -29,6 +29,7 @@ xbps-install -ySu \
 	vpm vsv \
 	ncurses-base \
 	openssh joe vim \
+	rsyslog \
 	jq
 
 xbps-alternatives -g vi -s vim-common


### PR DESCRIPTION
While working on alma, I found it didn't have the `ps` command, so I added it and a few other packages. This will bring centos up to parity with alma.

Tested by running through the docker build process then launching a docker container of the final image and checking for the packages.