### PR TITLE
Void linux should always start ssh

### DIFF
--- a/void/helpers/build.sh
+++ b/void/helpers/build.sh
@@ -42,6 +42,6 @@ svdir=/etc/runit/runsvdir/default
 # Disable default agetty services
 rm -f $svdir/agetty-tty*
 
-# Enable serial console
+# Enable serial console and ssh
 ln -s /etc/sv/agetty-console $svdir/
-
+ln -s /etc/sv/sshd $svdir/


### PR DESCRIPTION
This is necessary for cloud environments.