### PR TITLE
CentOS images should include ping command

### DIFF
--- a/alma/helpers/build.sh
+++ b/alma/helpers/build.sh
@@ -9,6 +9,7 @@ dnf install -y --allowerasing \
     binutils \
     dialog \
     diffutils \
+    iputils \
     openssh-server \
     openssh-clients \
     procps-ng \

--- a/centos-stream/helpers/build.sh
+++ b/centos-stream/helpers/build.sh
@@ -9,6 +9,7 @@ dnf install -y --allowerasing \
     binutils \
     dialog \
     diffutils \
+    iputils \
     openssh-server \
     openssh-clients \
     procps-ng \

--- a/fedora/helpers/build.sh
+++ b/fedora/helpers/build.sh
@@ -9,6 +9,7 @@ dnf install -y --allowerasing \
     binutils \
     dialog \
     diffutils \
+    iputils \
     openssh-server \
     openssh-clients \
     procps-ng \


### PR DESCRIPTION
While doing final testing I realized that centos images don't have iputils installed, which contains ping. The alma images I created for testing *do* have it by default, so I hadn't noticed before.

I didn't try fedora since we (Triton) don't ship fedora images, but I figured I might as well make iputils an explicit install for all three just in case.