### PR TITLE
lx-images#38: Debian/Ubuntu regenerate_ssh_host_keys should not disable itself

### DIFF
--- a/debian/helpers/regenerate_ssh_host_keys.service
+++ b/debian/helpers/regenerate_ssh_host_keys.service
@@ -5,7 +5,6 @@ Before=ssh.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ssh-keygen -A -v
-ExecStartPost=/bin/systemctl disable regenerate_ssh_host_keys
 
 [Install]
 WantedBy=multi-user.target

--- a/ubuntu/helpers/regenerate_ssh_host_keys.service
+++ b/ubuntu/helpers/regenerate_ssh_host_keys.service
@@ -5,7 +5,6 @@ Before=ssh.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ssh-keygen -A -v
-ExecStartPost=/bin/systemctl disable regenerate_ssh_host_keys
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #38 