### PR TITLE
RPM based distros should have passwd package installed

### DIFF
--- a/alma/helpers/build.sh
+++ b/alma/helpers/build.sh
@@ -12,6 +12,7 @@ dnf install -y --allowerasing \
     iputils \
     openssh-server \
     openssh-clients \
+    passwd \
     procps-ng \
     rsyslog \
     sudo \

--- a/centos-stream/helpers/build.sh
+++ b/centos-stream/helpers/build.sh
@@ -12,6 +12,7 @@ dnf install -y --allowerasing \
     iputils \
     openssh-server \
     openssh-clients \
+    passwd \
     procps-ng \
     rsyslog \
     sudo \

--- a/fedora/helpers/build.sh
+++ b/fedora/helpers/build.sh
@@ -12,6 +12,7 @@ dnf install -y --allowerasing \
     iputils \
     openssh-server \
     openssh-clients \
+    passwd \
     procps-ng \
     rsyslog \
     sudo \


### PR DESCRIPTION
Deb based distros and void already have it installed. But I could explicitly add it to all distros in case it's removed upstream, if anyone thinks that would be better.

Credit to @sreboot for reporting this.