### PR TITLE
Add debian 12 (bookworm)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,7 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
+                    - bookworm
                     - bullseye
                     - buster
 


### PR DESCRIPTION
Devuan's Daedalus (equivalent of deb12/bookworm) is not yet released, so I didn't include it.