### PR TITLE
Remove centos-stream-8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -182,7 +182,6 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
-                    - 8
                     - 9
 
         name: Build Centos Stream ${{ matrix.RELEASE }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Curently the following linuxes are supported
 * Devuan Beowulf
 * Devuan Chimeara
 * Void Linux
-* CentOS stream 8
 * CentOS stream 9
 * Fedora 35
 * Alpine 3


### PR DESCRIPTION
Centos Stream 8 repos have been shut down and it is no longer possible to install packages.