### PR TITLE
Fix ubuntu 24 images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,6 @@ on:
             - '**.md'
         branches:
             - master
-            - 202501
 jobs:
     prepare:
         name: Create Release
@@ -38,6 +37,7 @@ jobs:
                     - 24.04
                     - 22.04
                     - 20.04
+                    - 18.04
 
         name: Build Ubuntu ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
             - '**.md'
         branches:
             - master
+            - 202501
 jobs:
     prepare:
         name: Create Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,6 @@ jobs:
                     - 24.04
                     - 22.04
                     - 20.04
-                    - 18.04
 
         name: Build Ubuntu ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,5 +2,5 @@ ARG UBUNTU_RELEASE
 FROM ubuntu:${UBUNTU_RELEASE}
 COPY helpers /helpers
 ARG UBUNTU_RELEASE=${UBUNTU_RELEASE}
-RUN apt-get update && apt-get install -y systemd
+RUN apt-get update && apt-get install -y systemd systemd-sysv systemd-timesyncd libnss-systemd libpam-systemd libsystemd0 networkd-dispatcher
 RUN chmod 0 /bin/systemctl;cd /helpers; sh build.sh; cd /; rm -rf helpers;chmod 755 /bin/systemctl

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,4 +2,5 @@ ARG UBUNTU_RELEASE
 FROM ubuntu:${UBUNTU_RELEASE}
 COPY helpers /helpers
 ARG UBUNTU_RELEASE=${UBUNTU_RELEASE}
+RUN apt-get update && apt-get install -y systemd
 RUN chmod 0 /bin/systemctl;cd /helpers; sh build.sh; cd /; rm -rf helpers;chmod 755 /bin/systemctl

--- a/ubuntu/helpers/build.sh
+++ b/ubuntu/helpers/build.sh
@@ -5,6 +5,9 @@ echo Installing Ubuntu $UBUNTU_RELEASE
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -yq apt-utils
+if ! command -v unminimize; then
+    apt-get install -yq unminimize
+fi
 yes | unminimize
 apt-get install -yq \
     systemd-sysv \


### PR DESCRIPTION
Ubuntu 24 docker image has removed systemd entirely (presumably because of Docker's single process model), and the `unminimize` command has been moved to its own package that's not installed by default.

These changes are required to build new Ubuntu 24.04 images.