### PR TITLE
April 2025 housekeeping

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
                   xz $tar
             - name: Upload Release Asset
               id: upload_release_asset
-              uses: sekwah41/upload-release-assets@v1.1.0
+              uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -136,7 +136,7 @@ jobs:
                   xz $tar
             - name: Upload Release Asset
               id: upload_release_asset
-              uses: sekwah41/upload-release-assets@v1.1.0
+              uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -168,7 +168,7 @@ jobs:
                   xz $tar
             - name: Upload Release Asset
               id: upload_release_asset
-              uses: sekwah41/upload-release-assets@v1.1.0
+              uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -205,7 +205,7 @@ jobs:
                   xz $tar
             - name: Upload Release Asset
               id: upload_release_asset
-              uses: sekwah41/upload-release-assets@v1.1.0
+              uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -242,7 +242,7 @@ jobs:
                   xz $tar
             - name: Upload Release Asset
               id: upload_release_asset
-              uses: sekwah41/upload-release-assets@v1.1.0
+              uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -263,7 +263,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Build Image
               id: build_image
@@ -300,7 +300,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Build Image
               id: build_image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,6 @@ jobs:
                     - 24.04
                     - 22.04
                     - 20.04
-                    - 18.04
 
         name: Build Ubuntu ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
                   xz $tar
             - name: Upload Release Asset
               id: upload_release_asset
-              uses: sekwah41/upload-release-assets@v1.1.0
+              uses: actions/upload-release-asset@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -219,7 +219,7 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
-                    - 35
+                    - 41
 
         name: Build fedora ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,6 @@ jobs:
                 RELEASE:
                     - bookworm
                     - bullseye
-                    - buster
 
         name: Build Debian ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -112,8 +111,8 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
+                    - daedalus
                     - chimaera
-                    - beowulf
 
         name: Build Devuan ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Curently the following linuxes are supported
 * Devuan Chimeara
 * Void Linux
 * CentOS stream 9
-* Fedora 35
+* Fedora 41
 * Alpine 3
 
 See [Releases](https://github.com/omniosorg/lx-images/releases) for image downloads.

--- a/README.md
+++ b/README.md
@@ -15,5 +15,7 @@ Curently the following linuxes are supported
 * CentOS stream 9
 * Fedora 41
 * Alpine 3
+* Alma 8
+* Alma 9
 
 See [Releases](https://github.com/omniosorg/lx-images/releases) for image downloads.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Curently the following linuxes are supported
 * Ubuntu 20.04
 * Ubuntu 22.04
 * Ubuntu 24.04
-* Debian Buster
 * Debian Bullseye
-* Devuan Beowulf
+* Debian Bookworm
 * Devuan Chimeara
+* Devuan Daedalus
 * Void Linux
 * CentOS stream 9
 * Fedora 41

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Curently the following linuxes are supported
 
-* Ubuntu 18.04
 * Ubuntu 20.04
 * Ubuntu 22.04
 * Ubuntu 24.04

--- a/alma/Dockerfile
+++ b/alma/Dockerfile
@@ -2,4 +2,4 @@ ARG ALMA_RELEASE
 FROM almalinux:${ALMA_RELEASE}
 COPY helpers /helpers
 ARG ALMA_RELEASE=${ALMA_RELEASE}
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,4 +2,4 @@ ARG ALPINE_RELEASE
 FROM alpine:${ALPINE_RELEASE}
 COPY helpers /helpers
 ARG ALPINE_RELEASE=${ALPINE_RELEASE}
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/centos-stream/Dockerfile
+++ b/centos-stream/Dockerfile
@@ -2,4 +2,4 @@ ARG CENTOS_RELEASE
 FROM quay.io/centos/centos:${CENTOS_RELEASE}
 COPY helpers /helpers
 ARG CENTOS_RELEASE=${CENTOS_RELEASE}
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -3,4 +3,4 @@ FROM debian:${DEBIAN_RELEASE}
 ARG DEBIAN_RELEASE
 ENV DEBIAN_RELEASE ${DEBIAN_RELEASE}
 COPY helpers /helpers
-RUN chmod 0 /bin/systemctl;cd /helpers; sh build.sh; cd /; rm -rf helpers;chmod 755 /bin/systemctl
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/debian/helpers/build.sh
+++ b/debian/helpers/build.sh
@@ -71,4 +71,4 @@ rm dtracetools-lx_1.0_amd64.deb
 mkdir -p /var/svc /var/db
 
 # remove .dockerenv file because lx is not a docker
-rm /.dockerenv
+rm -f /.dockerenv

--- a/devuan/Dockerfile
+++ b/devuan/Dockerfile
@@ -3,4 +3,4 @@ FROM dyne/devuan:${DEVUAN_RELEASE}
 ARG DEVUAN_RELEASE
 ENV DEVUAN_RELEASE ${DEVUAN_RELEASE}
 COPY helpers /helpers
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/devuan/helpers/build.sh
+++ b/devuan/helpers/build.sh
@@ -31,11 +31,6 @@ apt-get -qq clean
 rm -rf /var/lib/apt/lists/*
 apt-get -qq autoremove
 
-# disable services we do not need
-for s in checkroot-bootclean.sh; do
-	update-rc.d $s defaults-disabled
-done
-
 # Prevents apt-get upgrade issue when upgrading in a container environment.
 cp makedev /etc/apt/preferences.d/makedev
 cp locale.conf /etc/locale.conf
@@ -63,4 +58,4 @@ rm dtracetools-lx_1.0_amd64.deb
 mkdir -p /var/svc /var/db
 
 # remove .dockerenv file because lx is not a docker
-rm /.dockerenv
+rm -f /.dockerenv

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -2,4 +2,4 @@ ARG FEDORA_RELEASE
 FROM fedora:${FEDORA_RELEASE}
 COPY helpers /helpers
 ARG FEDORA_RELEASE=${FEDORA_RELEASE}
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/rocky/Dockerfile
+++ b/rocky/Dockerfile
@@ -2,4 +2,4 @@ ARG ROCKY_RELEASE
 FROM rockylinux:${ROCKY_RELEASE}
 COPY helpers /helpers
 ARG ROCKY_RELEASE=${ROCKY_RELEASE}
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -3,4 +3,4 @@ FROM ubuntu:${UBUNTU_RELEASE}
 COPY helpers /helpers
 ARG UBUNTU_RELEASE=${UBUNTU_RELEASE}
 RUN apt-get update && apt-get install -y systemd systemd-sysv systemd-timesyncd libnss-systemd libpam-systemd libsystemd0 networkd-dispatcher
-RUN chmod 0 /bin/systemctl;cd /helpers; sh build.sh; cd /; rm -rf helpers;chmod 755 /bin/systemctl
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/void/Dockerfile
+++ b/void/Dockerfile
@@ -1,3 +1,3 @@
 FROM ghcr.io/void-linux/void-glibc-full
 COPY helpers /helpers
-RUN cd /helpers; sh build.sh; cd /; rm -rf helpers
+RUN cd /helpers && sh build.sh && cd / && rm -rf helpers

--- a/void/Dockerfile
+++ b/void/Dockerfile
@@ -1,3 +1,3 @@
-FROM voidlinux/voidlinux
+FROM ghcr.io/void-linux/void-glibc-full
 COPY helpers /helpers
 RUN cd /helpers; sh build.sh; cd /; rm -rf helpers

--- a/void/helpers/build.sh
+++ b/void/helpers/build.sh
@@ -30,7 +30,8 @@ xbps-install -ySu \
 	ncurses-base \
 	openssh joe vim \
 	rsyslog \
-	jq
+	jq \
+	bash
 
 xbps-alternatives -g vi -s vim-common
 


### PR DESCRIPTION
- Make all builds fail on build script failure. Without this partial builds were being shipped. That was bad.
- Disable EOL distros
- Update to latest for some others
- Clean up README to match what we currently ship
- Fix build errors