### PR TITLE
July 2026 Housekeeping

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,9 +34,9 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
+                    - 26.04
                     - 24.04
                     - 22.04
-                    - 20.04
 
         name: Build Ubuntu ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -73,8 +73,8 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
+                    - trixie
                     - bookworm
-                    - bullseye
 
         name: Build Debian ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -111,8 +111,8 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
+                    - excalibur
                     - daedalus
-                    - chimaera
 
         name: Build Devuan ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -182,6 +182,7 @@ jobs:
             matrix:
                 RELEASE:
                     - 9
+                    - 10
 
         name: Build Centos Stream ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -218,7 +219,7 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
-                    - 41
+                    - 44
 
         name: Build fedora ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -255,8 +256,8 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
-                    - 8
                     - 9
+                    - 10
 
         name: Build AlmaLinux ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest
@@ -292,8 +293,8 @@ jobs:
         strategy:
             matrix:
                 RELEASE:
-                    - 8
                     - 9
+                    - 10
 
         name: Build RockyLinux ${{ matrix.RELEASE }}
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,18 +4,21 @@
 
 Curently the following linuxes are supported
 
-* Ubuntu 20.04
 * Ubuntu 22.04
 * Ubuntu 24.04
-* Debian Bullseye
+* Ubuntu 26.04
 * Debian Bookworm
-* Devuan Chimeara
+* Debian Trixie
 * Devuan Daedalus
+* Devuan Excalibur
 * Void Linux
 * CentOS stream 9
-* Fedora 41
+* CentOS stream 10
+* Fedora 44
 * Alpine 3
-* Alma 8
 * Alma 9
+* Alma 10
+* Rocky 9
+* Rocky 10
 
 See [Releases](https://github.com/omniosorg/lx-images/releases) for image downloads.

--- a/rocky/Dockerfile
+++ b/rocky/Dockerfile
@@ -1,5 +1,5 @@
 ARG ROCKY_RELEASE
-FROM rockylinux:${ROCKY_RELEASE}
+FROM rockylinux/rockylinux:${ROCKY_RELEASE}
 COPY helpers /helpers
 ARG ROCKY_RELEASE=${ROCKY_RELEASE}
 RUN cd /helpers && sh build.sh && cd / && rm -rf helpers


### PR DESCRIPTION
Retire some old images, bring in some new ones:
```diff
-* Ubuntu 20.04
+* Ubuntu 26.04
-* Debian Bullseye
+* Debian Trixie
-* Devuan Chimeara
+* Devuan Excalibur
+* CentOS stream 10
-* Fedora 41
+* Fedora 44
-* Alma 8
+* Alma 10
+* Rocky 10
```

Also fix Rocky Linux Dockerfile source so that 10 can be built in addition to 9.

Note: No testing of these images under LX has been done (yet?) Only verification that the docker builds all succeed.
I expect issues similar to what we saw in #48.
Hopefully if someone has an actual need for one of the broken images they will let us know and we can see if it's easy to fix, or if LX is getting too old to look close enough to modern linux....